### PR TITLE
Do not use the dnsruby gem

### DIFF
--- a/email_verifier.gemspec
+++ b/email_verifier.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_runtime_dependency(%q<dnsruby>, [">= 1.5"])
   gem.license = 'MIT'
 end

--- a/lib/email_verifier/checker.rb
+++ b/lib/email_verifier/checker.rb
@@ -1,5 +1,5 @@
 require 'net/smtp'
-require 'dnsruby'
+require 'resolv'
 
 class EmailVerifier::Checker
 
@@ -22,14 +22,10 @@ class EmailVerifier::Checker
 
   def list_mxs(domain)
     return [] unless domain
-    res = Dnsruby::DNS.new
-    mxs = []
-    res.each_resource(domain, 'MX') do |rr|
-      mxs << { priority: rr.preference, address: rr.exchange.to_s }
+    mxs = Resolv::DNS.new.getresources(domain, Resolv::DNS::Resource::IN::MX).map do |mx|
+      { priority: mx.preference, address: mx.exchange.to_s }
     end
     mxs.sort_by { |mx| mx[:priority] }
-  rescue Dnsruby::NXDomain
-    raise EmailVerifier::NoMailServerException.new("#{domain} does not exist") 
   end
 
   def is_connected


### PR DESCRIPTION
There is no need for an external dependency and that gem has bugs
parsing the resolv.conf file. An example is a default resolv.conf in
kubernetes which causes a nil reference error